### PR TITLE
Refactor header into its own file.

### DIFF
--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -10,20 +10,7 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   </head>
   <body>
-    <header>
-        <div id="wordmark" href="/">Jay Mohile</div>
-        <nav>
-            <span id="theme-toggle" class="material-icons" onclick="toggleTheme()">brightness_4</span>
-            <a href="/personal.html">
-                <div class="hover-indicator"></div>
-                <div class="title">Personal</div>
-            </a>
-            <a href="/projects.html">
-                <div class="hover-indicator"></div>
-                <div class="title" >Projects</div>
-            </a>
-        </nav>
-    </header>
+    <header></header>
 
     <main id="landing">
         <img id="hero" src="/images/jay_landing.png"/>
@@ -31,4 +18,6 @@
         <div id="watermark">Portfolio.</div>
     </main>
   </body>
+
+  <script src="/js/header.js"></script>
 </html>

--- a/portfolio/src/main/webapp/js/header.js
+++ b/portfolio/src/main/webapp/js/header.js
@@ -1,0 +1,10 @@
+/**
+ * Load header object from the server and inject into UI.
+ */
+async function loadHeader(){
+    const response = await fetch("/partials/header.html");
+    const html = await response.text();
+    document.querySelector("header").outerHTML = html;
+}
+
+loadHeader();

--- a/portfolio/src/main/webapp/partials/header.html
+++ b/portfolio/src/main/webapp/partials/header.html
@@ -1,5 +1,5 @@
 <header>
-    <div id="wordmark" href="/">Jay Mohile</div>
+    <a id="wordmark" href="/">Jay Mohile</a>
     <nav>
         <span id="theme-toggle" class="material-icons" onclick="toggleTheme()">brightness_4</span>
         <a href="/personal.html">

--- a/portfolio/src/main/webapp/partials/header.html
+++ b/portfolio/src/main/webapp/partials/header.html
@@ -1,0 +1,14 @@
+<header>
+    <div id="wordmark" href="/">Jay Mohile</div>
+    <nav>
+        <span id="theme-toggle" class="material-icons" onclick="toggleTheme()">brightness_4</span>
+        <a href="/personal.html">
+            <div class="hover-indicator"></div>
+            <div class="title">Personal</div>
+        </a>
+        <a href="/projects.html">
+            <div class="hover-indicator"></div>
+            <div class="title" >Projects</div>
+        </a>
+    </nav>
+</header>

--- a/portfolio/src/main/webapp/personal.html
+++ b/portfolio/src/main/webapp/personal.html
@@ -10,20 +10,7 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   </head>
   <body>
-    <header>
-        <div id="wordmark">Jay Mohile</div>
-        <nav>
-            <span id="theme-toggle" class="material-icons" onclick="toggleTheme()">brightness_4</span>
-            <a href="/personal.html">
-                <div class="hover-indicator"></div>
-                <div class="title">Personal</div>
-            </a>
-            <a href="/projects.html">
-                <div class="hover-indicator"></div>
-                <div class="title" >Projects</div>
-            </a>
-        </nav>
-    </header>
+    <header> </header>
 
     <main id="personal">
         <article id="bio">
@@ -60,4 +47,5 @@
         <div id="watermark">Personal.</div>
     </main>
   </body>
+  <script src="/js/header.js"></script>
 </html>

--- a/portfolio/src/main/webapp/project-detail.html
+++ b/portfolio/src/main/webapp/project-detail.html
@@ -10,20 +10,7 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   </head>
   <body>
-    <header>
-        <div id="wordmark" href="/">Jay Mohile</div>
-        <nav>
-            <span id="theme-toggle" class="material-icons" onclick="toggleTheme()">brightness_4</span>
-            <a href="/personal.html">
-                <div class="hover-indicator"></div>
-                <div class="title">Personal</div>
-            </a>
-            <a href="/projects.html">
-                <div class="hover-indicator"></div>
-                <div class="title" >Projects</div>
-            </a>
-        </nav>
-    </header>
+    <header></header>
 
     <main id="project-detail">
         <h1 id="name">Project Name</h1>
@@ -39,4 +26,5 @@
     <!-- This must be included at the end, to allow above templates to be added to dom. -->
     <script type="module" src="js/project-detail.js"></script>
   </body>
+  <script src="/js/header.js"></script>
 </html>

--- a/portfolio/src/main/webapp/projects.html
+++ b/portfolio/src/main/webapp/projects.html
@@ -10,20 +10,7 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   </head>
   <body>
-    <header>
-        <div id="wordmark" href="/">Jay Mohile</div>
-        <nav>
-            <span id="theme-toggle" class="material-icons" onclick="toggleTheme()">brightness_4</span>
-            <a href="/personal.html">
-                <div class="hover-indicator"></div>
-                <div class="title">Personal</div>
-            </a>
-            <a href="/projects.html">
-                <div class="hover-indicator"></div>
-                <div class="title" >Projects</div>
-            </a>
-        </nav>
-    </header>
+    <header></header>
 
     <main id="projects">
         <!-- A list of all projects matching selected tag-filters -->
@@ -55,4 +42,5 @@
     <!-- This must be included at the end, to allow above templates to be added to dom. -->
     <script type="module" src="js/projects.js"></script>
   </body>
+  <script src="/js/header.js"></script>
 </html>

--- a/portfolio/src/main/webapp/styles/sass/header.scss
+++ b/portfolio/src/main/webapp/styles/sass/header.scss
@@ -11,6 +11,8 @@ header {
     font-size: 30px;
     color: var(--text-color);
     font-weight: 600;
+    text-decoration: none;
+
     animation: wordmark-entry 1s forwards ease-out;
 
     @keyframes wordmark-entry {


### PR DESCRIPTION
**Background**
The header is reused without changes on nearly every page of the portfolio. Right now there's significant code duplication that makes it inconvenient to push changes (while dirtying the git history).

**Work Done**
This simple refactor creates a standalone header.html (within a partials/ directory that may be used for other elements in the future.) And loads it client-side.