### PR TITLE
fix: close tag on malformed project-detail page

### DIFF
--- a/portfolio/src/main/webapp/project-detail.html
+++ b/portfolio/src/main/webapp/project-detail.html
@@ -24,7 +24,7 @@
             <h2>Links</h2>
             <ul id="links">
             </ul>
-          
+        </section>  
         <section id="comments">
             <div id="header">
                 <h2>Comments</h2>


### PR DESCRIPTION
An unclosed tag on the project-detail page was ruining formatting, must have regressed during a merge conflict.