### PR TITLE
Feature/meeting query algo

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -52,9 +52,21 @@ public final class FindMeetingQuery {
      */
     int blockExtent = TimeRange.START_OF_DAY;
 
-    /** TODO: Add loop to go through shifts. */
+    for (Event event : sortedEvents) {
+      TimeRange when = event.getWhen();
+      if (when.start() > blockExtent) { // This is a potential window.
+        if (windowIsLongEnough(blockExtent, when.start(), request)) {
+          timeSlots.add(
+            /** Add non-inclusive window because it can't overlap with the start of this event. */
+            TimeRange.fromStartEnd(blockExtent, when.start(), false)
+          );
+        }
+      }
 
-    /** At this point there are no more shifts, so remaining must be a potential window. */
+      blockExtent = when.end();
+    }
+
+    /** At this point there are no more events, so remaining must be a potential window. */
     if (blockExtent < TimeRange.END_OF_DAY) {
       if (windowIsLongEnough(blockExtent, TimeRange.END_OF_DAY, request)) {
         timeSlots.add(

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -38,15 +38,15 @@ public final class FindMeetingQuery {
     ArrayList<Event> sortedEvents = new ArrayList<>(events);
     sortedEvents.sort(EVENT_COMPARATOR);
 
-    /** 
+    /**
      * We consider this problem in terms of 'windows' and 'blocks'.
      * |-----A-----|                  |------A-----|
      *       |----------B-----|       |---B---|
-     * 
+     *
      * |______________________||______|
      *        block              window
-     * 
-     * We iterate shifts to identify the right-most extent of a block. 
+     *
+     * We iterate shifts to identify the right-most extent of a block.
      * If we find a shift that start *after* this point, the difference is a window.
      * That window is a possible meeting spot, if long enough.
      */
@@ -54,11 +54,26 @@ public final class FindMeetingQuery {
 
     /** TODO: Add loop to go through shifts. */
 
-    /** At this point there are no more shifts, so remaining must be a window. */
+    /** At this point there are no more shifts, so remaining must be a potential window. */
     if (blockExtent < TimeRange.END_OF_DAY) {
-        timeSlots.add(TimeRange.fromStartEnd(blockExtent, TimeRange.END_OF_DAY, true));
+      if (windowIsLongEnough(blockExtent, TimeRange.END_OF_DAY, request)) {
+        timeSlots.add(
+          TimeRange.fromStartEnd(blockExtent, TimeRange.END_OF_DAY, true)
+        );
+      }
     }
     return timeSlots;
+  }
+
+  /*
+   * Ensure a potential window is long enough to fit meet request.
+   * @param from     start of window in minutes.
+   * @param end      end of window in minutes.
+   * @param request  target meeting request.
+   * @return         whether window is long enough.
+   */
+  private boolean windowIsLongEnough(int from, int to, MeetingRequest request) {
+    return (to - from) >= (int) request.getDuration();
   }
 }
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -38,6 +38,26 @@ public final class FindMeetingQuery {
     ArrayList<Event> sortedEvents = new ArrayList<>(events);
     sortedEvents.sort(EVENT_COMPARATOR);
 
+    /** 
+     * We consider this problem in terms of 'windows' and 'blocks'.
+     * |-----A-----|                  |------A-----|
+     *       |----------B-----|       |---B---|
+     * 
+     * |______________________||______|
+     *        block              window
+     * 
+     * We iterate shifts to identify the right-most extent of a block. 
+     * If we find a shift that start *after* this point, the difference is a window.
+     * That window is a possible meeting spot, if long enough.
+     */
+    int blockExtent = TimeRange.START_OF_DAY;
+
+    /** TODO: Add loop to go through shifts. */
+
+    /** At this point there are no more shifts, so remaining must be a window. */
+    if (blockExtent < TimeRange.END_OF_DAY) {
+        timeSlots.add(TimeRange.fromStartEnd(blockExtent, TimeRange.END_OF_DAY, true));
+    }
     return timeSlots;
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -15,6 +15,7 @@
 package com.google.sps;
 
 import com.google.sps.TimeRange;
+import java.lang.Math;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -62,6 +63,10 @@ public final class FindMeetingQuery {
         request
       );
 
+      if (containsMandatoryAttendees == false) {
+        continue;
+      }
+
       if (when.start() > blockExtent) { // This is a potential window.
         if (windowIsLongEnough(blockExtent, when.start(), request)) {
           timeSlots.add(
@@ -71,9 +76,7 @@ public final class FindMeetingQuery {
         }
       }
 
-      if (containsMandatoryAttendees) {
-        blockExtent = when.end();
-      }
+      blockExtent = Math.max(blockExtent, when.end());
     }
 
     /* At this point there are no more events, so remaining must be a potential window. */

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -14,10 +14,31 @@
 
 package com.google.sps;
 
+import com.google.sps.TimeRange;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 
 public final class FindMeetingQuery {
-  public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
+  /** Used to sort events by start time. */
+  public static final Comparator<Event> EVENT_COMPARATOR = new Comparator<Event>() {
+
+    @Override
+    public int compare(Event a, Event b) {
+      return TimeRange.ORDER_BY_START.compare(a.getWhen(), b.getWhen());
+    }
+  };
+
+  public Collection<TimeRange> query(
+    Collection<Event> events,
+    MeetingRequest request
+  ) {
+    ArrayList<TimeRange> timeSlots = new ArrayList<>();
+
+    ArrayList<Event> sortedEvents = new ArrayList<>(events);
+    sortedEvents.sort(EVENT_COMPARATOR);
+
+    return timeSlots;
   }
 }
+

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -125,7 +125,7 @@ public final class FindMeetingQueryTest {
   @Test
   public void everyAttendeeIsConsideredWithOptionalUnavailable() {
     // Have each person have different events. We should see three options because each person has
-    // split the restricted times.
+    // split the restricted times. The optional should be ignored because there is no way to include them.
     //
     // Events  :       |--A--|     |--B--|
     //           |----------C optional---------|
@@ -156,13 +156,14 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void everyAttendeeIsConsideredWithOptionalAvailable() {
-    // We should see two options.
-    // split the restricted times.
+    // We should see two options. A and B have three options, but 
+    // Since it is possible to have (less options) that also include C, those
+    // are preferred.
     //
     // Events  :       |--A--|     |--B--|
     //                       |--C option-|
     // Day     : |-----------------------------|
-    // Options : |--1--|     |--2--|     |--3--|
+    // Options : |--1--|                 |--2--|
 
     Collection<Event> events = Arrays.asList(
         new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
@@ -179,8 +180,10 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
-            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+        Arrays.asList(
+          TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+          TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true)
+        );
 
     Assert.assertEquals(expected, actual);
   }
@@ -290,7 +293,7 @@ public final class FindMeetingQueryTest {
     @Test
   public void justEnoughRoomOptionalTooShort() {
     // Have one person, but make it so that there is just enough room at one point in the day to
-    // have the meeting. There is also one optional, but without enough room.
+    // have the meeting. There is also one optional, but without enough room, so they are ignored.
     //
     // Events  : |--A--|     |----A----|
     //                 |--| <- Optional C
@@ -366,12 +369,11 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void onlyOptionalNoRoom() {
-    // Have each person have different events. We should see two options because each person has
-    // split the restricted times.
+    // Two optional attendees, no mandatory. 
     //
     // Events  : |--A--|--B--------------------|
     // Day     : |-----------------------------|
-    // Options : |--1--|     |--2--|     |--3--|
+    // Options :    NONE
 
     Collection<Event> events = Arrays.asList(
         new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM, true),

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -34,6 +34,7 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -116,6 +117,69 @@ public final class FindMeetingQueryTest {
     Collection<TimeRange> expected =
         Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void everyAttendeeIsConsideredWithOptionalUnavailable() {
+    // Have each person have different events. We should see three options because each person has
+    // split the restricted times.
+    //
+    // Events  :       |--A--|     |--B--|
+    //           |----------C optional---------|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.WHOLE_DAY, 
+            Arrays.asList(PERSON_C))
+        );
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void everyAttendeeIsConsideredWithOptionalAvailable() {
+    // We should see two options.
+    // split the restricted times.
+    //
+    // Events  :       |--A--|     |--B--|
+    //                       |--C option-|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_1_HOUR), 
+            Arrays.asList(PERSON_C))
+        );
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
@@ -211,10 +275,39 @@ public final class FindMeetingQueryTest {
     Collection<Event> events = Arrays.asList(
         new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, false),
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+    @Test
+  public void justEnoughRoomOptionalTooShort() {
+    // Have one person, but make it so that there is just enough room at one point in the day to
+    // have the meeting. There is also one optional, but without enough room.
+    //
+    // Events  : |--A--|     |----A----|
+    //                 |--| <- Optional C
+    // Day     : |---------------------|
+    // Options :       |-----|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, 15),
+            Arrays.asList(PERSON_B))
+        );
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
@@ -264,6 +357,31 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void onlyOptionalNoRoom() {
+    // Have each person have different events. We should see two options because each person has
+    // split the restricted times.
+    //
+    // Events  : |--A--|--B--------------------|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, TimeRange.END_OF_DAY),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected = Arrays.asList();


### PR DESCRIPTION
**Work Done**
- Using test-driven dev, write algorithm to find potential meeting times given a set of mandatory/optional attendees and their pre-existing events.
- This approach contains a bit of duplication, since it divides the attendees into two classes: mandatory and optional. These two classes have almost identical logic, except for the fact that optional should only be considered if mandatory is fulfilled. 
 - I feel like there is a more elegant way to consider these two classes simultaneously
 - But for now, this works, and should serve as a good V1 until that can be found. 
 - Additionally all duplication is small-chunks, and located in very close proximity such that it doesn't take away from readability. As of now, abstracting things away to get rid of the duplication but keep the slight differences would probably be detrimental.

**ALL TESTS PASSING**